### PR TITLE
[NEW] Build openal.hdll statically

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/sndio"]
+	path = deps/sndio
+	url = https://github.com/ratchov/sndio

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/sndio"]
-	path = deps/sndio
-	url = https://github.com/ratchov/sndio

--- a/clone-code.cmd
+++ b/clone-code.cmd
@@ -1,5 +1,13 @@
 @echo off
+echo Cloning code: https://github.com/HaxeFoundation/hashlink
 git clone https://github.com/HaxeFoundation/hashlink hashlink
+echo Done
+echo Patching openal-static-build patch
+cd hashlink
+git apply ../patches/openal-static-build.patch
+cd ..
+echo Done
+
 REM  
 REM  Hashlink master branch must work with Heaps master. Using Hashlink
 REM  from master branch and Heaps with Haxelib can causes ABI mangling

--- a/clone-code.cmd
+++ b/clone-code.cmd
@@ -1,12 +1,15 @@
 @echo off
+echo ===============================================================
 echo Cloning code: https://github.com/HaxeFoundation/hashlink
 git clone https://github.com/HaxeFoundation/hashlink hashlink
 echo Done
+echo ===============================================================
 echo Patching openal-static-build patch
 cd hashlink
 git apply ../patches/openal-static-build.patch
 cd ..
 echo Done
+echo ===============================================================
 
 REM  
 REM  Hashlink master branch must work with Heaps master. Using Hashlink

--- a/clone-code.sh
+++ b/clone-code.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
+echo ===============================================================
+echo Cloning code: https://github.com/HaxeFoundation/hashlink ...
 git clone https://github.com/HaxeFoundation/hashlink hashlink
+echo Cloning done.
+echo ===============================================================
+echo Patching openal-static-build patch ...
+cd hashlink
+git apply ../patches/openal-static-build.patch
+cd ..
+echo Patching done.
+echo ===============================================================
 # 
 # Hashlink master branch must work with Heaps master. Using Hashlink
 # from master branch and Heaps with Haxelib can causes ABI mangling

--- a/deps/packages/l/libsndio-static/xmake.lua
+++ b/deps/packages/l/libsndio-static/xmake.lua
@@ -1,0 +1,47 @@
+package("libsndio")
+    set_homepage("https://sndio.org")
+    set_description("Sndio static build - for Linux only")
+    set_urls("https://sndio.org/sndio-$(version).tar.gz")
+
+    add_versions("1.9.0", "f30826fc9c07e369d3924d5fcedf6a0a53c0df4ae1f5ab50fe9cf280540f699a")
+
+    if is_plat("linux") then
+        add_deps("alsa-lib")
+    end
+
+    on_install("linux", function (package)
+        import("package.tools.autoconf")
+
+        local f = io.open("libsndio/Makefile.in", "a")
+        if f then
+            f:write("libsndio-static.a: ${OBJS}\n")
+            f:write("\t${AR} r libsndio-static.a ${OBJS}\n")
+
+            f:write("installstatic: libsndio-static.a install\n")
+            f:write("\tcp -R libsndio-static.a ${DESTDIR}${LIB_DIR}\n")
+            f:close()
+        else
+            print("ERROR: Can't find libsndio/Makefile.in")
+        end
+        local r = io.open("Makefile.in", "a")
+        if r then
+            r:write("installstatic:\n")
+            r:write("\tcd libsndio && ${MAKE} installstatic\n")
+            r:close()
+        end
+        io.cat("libsndio/Makefile.in")
+
+        local configs = {}
+        local buildenvs = autoconf.buildenvs(package, {packagedeps = "alsa-lib"})
+        autoconf.configure(package, configs, {envs = buildenvs})
+        os.vrunv("make", {}, {envs = buildenvs})
+        os.vrunv("make", {"install"}, {envs = buildenvs})
+        os.vrunv("make", {"installstatic"}, {envs = buildenvs})
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("sio_open", {includes = "sndio.h"}))
+    end)
+package_end()
+
+

--- a/install-haxe-libs.cmd
+++ b/install-haxe-libs.cmd
@@ -23,4 +23,4 @@ REM
 haxelib dev hlsdl hashlink/libs/sdl/
 haxelib dev hlopenal hashlink/libs/openal/
 haxelib dev hashlink hashlink/other/haxelib/
-haxelib git heaps https://github.com/HeapsIO/heaps.git master
+haxelib --always git heaps https://github.com/HeapsIO/heaps.git master

--- a/install-haxe-libs.sh
+++ b/install-haxe-libs.sh
@@ -24,4 +24,4 @@ echo ===============================================================
 haxelib dev hlsdl hashlink/libs/sdl/
 haxelib dev hlopenal hashlink/libs/openal/
 haxelib dev hashlink hashlink/other/haxelib/
-haxelib git heaps https://github.com/HeapsIO/heaps.git master
+haxelib --always git heaps https://github.com/HeapsIO/heaps.git master

--- a/patches/openal-static-build.patch
+++ b/patches/openal-static-build.patch
@@ -1,0 +1,483 @@
+diff --git a/libs/openal/openal.c b/libs/openal/openal.c
+index 49e95ae..24a5c63 100644
+--- a/libs/openal/openal.c
++++ b/libs/openal/openal.c
+@@ -10,11 +10,13 @@
+ 	#include <AL/alext.h>
+ #endif
+ 
++#define CALL(fun) fun##_dyn
++
+ // ----------------------------------------------------------------------------
+ // ALC
+ // ----------------------------------------------------------------------------
+ 
+-#define ALC_IMPORT(fun, t) t fun
++#define ALC_IMPORT(fun, t) t fun##_dyn
+ #include "ALCImports.h"
+ #undef ALC_IMPORT
+ 
+@@ -66,7 +68,7 @@ HL_PRIM int HL_NAME(alc_get_error)(ALCdevice *device) {
+ 
+ // Extension support
+ 
+-#define ALC_IMPORT(fun,t) fun = (t)alcGetProcAddress(device,#fun)
++#define ALC_IMPORT(fun,t) fun##_dyn = (t)alcGetProcAddress(device,#fun)
+ HL_PRIM void HL_NAME(alc_load_extensions)(ALCdevice *device) {
+ #	include "ALCImports.h"
+ }
+@@ -144,7 +146,7 @@ DEFINE_PRIM(_VOID,    alc_capture_samples,      TDEVICE _BYTES _I32);
+ // AL
+ // ----------------------------------------------------------------------------
+ 
+-#define AL_IMPORT(fun, t) t fun
++#define AL_IMPORT(fun, t) t fun##_dyn
+ #include "ALImports.h"
+ #undef AL_IMPORT
+ 
+@@ -224,7 +226,7 @@ HL_PRIM int HL_NAME(al_get_error)() {
+ 
+ // Extension support
+ 
+-#define AL_IMPORT(fun,t) fun = (t)alGetProcAddress(#fun)
++#define AL_IMPORT(fun,t) fun##_dyn = (t)alGetProcAddress(#fun)
+ HL_PRIM void HL_NAME(al_load_extensions)() {
+ #	include "ALImports.h"
+ }
+@@ -574,7 +576,7 @@ DEFINE_PRIM(_VOID, al_get_bufferiv, _I32 _I32 _BYTES);
+ // EXTENSIONS
+ // ----------------------------------------------------------------------------
+ 
+-#define CHECK_EXT(fun) if(fun == NULL) hl_error("Unsupported extension function")
++#define CHECK_EXT(fun) if(fun##_dyn == NULL) hl_error("Unsupported extension function")
+ 
+ // ----------------------------------------------------------------------------
+ #ifdef EXT_thread_local_context
+@@ -582,12 +584,12 @@ DEFINE_PRIM(_VOID, al_get_bufferiv, _I32 _I32 _BYTES);
+ 
+ HL_PRIM bool HL_NAME(alc_set_thread_context)(ALCcontext *context) {
+ 	CHECK_EXT(alcSetThreadContext);
+-	return alcSetThreadContext(context) == ALC_TRUE;
++	return CALL(alcSetThreadContext)(context) == ALC_TRUE;
+ }
+ 
+ HL_PRIM ALCcontext* HL_NAME(alc_get_thread_context)() {
+ 	CHECK_EXT(alcGetThreadContext);
+-	return alcGetThreadContext();
++	return CALL(alcGetThreadContext)();
+ }
+ 
+ DEFINE_PRIM(_BOOL,    alc_set_thread_context, TCONTEXT);
+@@ -600,17 +602,17 @@ DEFINE_PRIM(TCONTEXT, alc_get_thread_context, _NO_ARG);
+ 
+ HL_PRIM ALCdevice* HL_NAME(alc_loopback_open_device_soft)(vbyte *devicename) {
+ 	CHECK_EXT(alcLoopbackOpenDeviceSOFT);
+-	return alcLoopbackOpenDeviceSOFT((char*)devicename);
++	return CALL(alcLoopbackOpenDeviceSOFT)((char*)devicename);
+ }
+ 
+ HL_PRIM bool HL_NAME(alc_is_render_format_supported_soft)(ALCdevice *device, int freq, int channels, int type) {
+ 	CHECK_EXT(alcIsRenderFormatSupportedSOFT);
+-	return alcIsRenderFormatSupportedSOFT(device, freq, channels, type) == ALC_TRUE;
++	return CALL(alcIsRenderFormatSupportedSOFT)(device, freq, channels, type) == ALC_TRUE;
+ }
+ 
+ HL_PRIM void HL_NAME(alc_render_samples_soft)(ALCdevice *device, vbyte *buffer, int samples) {
+ 	CHECK_EXT(alcRenderSamplesSOFT);
+-	alcRenderSamplesSOFT(device, buffer, samples);
++	CALL(alcRenderSamplesSOFT)(device, buffer, samples);
+ }
+ 
+ DEFINE_PRIM(TDEVICE, alc_loopback_open_device_soft,       _BYTES);
+@@ -624,12 +626,12 @@ DEFINE_PRIM(_VOID,   alc_render_samples_soft,             TDEVICE _BYTES _I32);
+ 
+ HL_PRIM void HL_NAME(alc_device_pause_soft)(ALCdevice *device) {
+ 	CHECK_EXT(alcDevicePauseSOFT);
+-	alcDevicePauseSOFT(device);
++	CALL(alcDevicePauseSOFT)(device);
+ }
+ 
+ HL_PRIM void HL_NAME(alc_device_resume_soft)(ALCdevice *device) {
+ 	CHECK_EXT(alcDeviceResumeSOFT);
+-	alcDeviceResumeSOFT(device);
++	CALL(alcDeviceResumeSOFT)(device);
+ }
+ 
+ DEFINE_PRIM(_VOID, alc_device_pause_soft,  TDEVICE);
+@@ -642,12 +644,12 @@ DEFINE_PRIM(_VOID, alc_device_resume_soft, TDEVICE);
+ 
+ HL_PRIM vbyte* HL_NAME(alc_get_stringi_soft)(ALCdevice *device, int param, int index) {
+ 	CHECK_EXT(alcGetStringiSOFT);
+-	return (vbyte*)alcGetStringiSOFT(device, param, index);
++	return (vbyte*)CALL(alcGetStringiSOFT)(device, param, index);
+ }
+ 
+ HL_PRIM bool HL_NAME(alc_reset_device_soft)(ALCdevice *device, vbyte *attribs) {
+ 	CHECK_EXT(alcResetDeviceSOFT);
+-	return alcResetDeviceSOFT(device, (ALCint*)attribs) == ALC_TRUE;
++	return CALL(alcResetDeviceSOFT)(device, (ALCint*)attribs) == ALC_TRUE;
+ }
+ 
+ DEFINE_PRIM(_BYTES, alc_get_stringi_soft,  TDEVICE _I32 _I32);
+@@ -660,7 +662,7 @@ DEFINE_PRIM(_BOOL,  alc_reset_device_soft, TDEVICE _BYTES);
+ 
+ HL_PRIM void HL_NAME(al_buffer_data_static)(unsigned buffer, int format, vbyte *data, int len, int freq) {
+ 	CHECK_EXT(alBufferDataStatic);
+-	alBufferDataStatic(buffer, format, data, len, freq);
++	CALL(alBufferDataStatic)(buffer, format, data, len, freq);
+ }
+ 
+ DEFINE_PRIM(_VOID, al_buffer_data_static, _I32 _I32 _BYTES _I32 _I32);
+@@ -672,7 +674,7 @@ DEFINE_PRIM(_VOID, al_buffer_data_static, _I32 _I32 _BYTES _I32 _I32);
+ 
+ HL_PRIM void HL_NAME(al_buffer_sub_data_soft)(unsigned buffer, int format, vbyte *data, int offset, int length) {
+ 	CHECK_EXT(alBufferSubDataSOFT);
+-	alBufferSubDataSOFT(buffer, format, data, offset, length);
++	CALL(alBufferSubDataSOFT)(buffer, format, data, offset, length);
+ }
+ 
+ DEFINE_PRIM(_VOID, al_buffer_sub_data_soft, _I32 _I32 _BYTES _I32 _I32);
+@@ -685,12 +687,12 @@ DEFINE_PRIM(_VOID, al_buffer_sub_data_soft, _I32 _I32 _BYTES _I32 _I32);
+ HL_PRIM void HL_NAME(al_request_foldback_start)(int mode, int count, int length, vbyte *mem, vclosure *callback) {
+ 	CHECK_EXT(alRequestFoldbackStart);
+ 	if (callback->hasValue) if( callback->hasValue ) hl_error("Cannot set foldback on closure callback");
+-	alRequestFoldbackStart(mode, count, length, (ALfloat*)mem, (LPALFOLDBACKCALLBACK)callback->fun);
++	CALL(alRequestFoldbackStart)(mode, count, length, (ALfloat*)mem, (LPALFOLDBACKCALLBACK)callback->fun);
+ }
+ 
+ HL_PRIM void HL_NAME(al_request_foldback_stop)() {
+ 	CHECK_EXT(alRequestFoldbackStop);
+-	alRequestFoldbackStop();
++	CALL(alRequestFoldbackStop)();
+ }
+ 
+ DEFINE_PRIM(_VOID, al_request_foldback_start, _I32 _I32 _I32 _BYTES _FUN(_VOID, _I32 _I32));
+@@ -704,22 +706,22 @@ DEFINE_PRIM(_VOID, al_request_foldback_stop,  _NO_ARG);
+ 
+ HL_PRIM void HL_NAME(al_buffer_samples_soft)(unsigned buffer, int samplerate, int internatlformat, int samples, int channels, int type, vbyte *data) {
+ 	CHECK_EXT(alBufferSamplesSOFT);
+-	alBufferSamplesSOFT(buffer, samplerate, internatlformat, samples, channels, type, data);
++	CALL(alBufferSamplesSOFT)(buffer, samplerate, internatlformat, samples, channels, type, data);
+ }
+ 
+ HL_PRIM void HL_NAME(al_buffer_sub_samples_soft)(unsigned buffer, int offset, int samples, int channels, int type, vbyte *data) {
+ 	CHECK_EXT(alBufferSubSamplesSOFT);
+-	alBufferSubSamplesSOFT(buffer, offset, samples, channels, type, data);
++	CALL(alBufferSubSamplesSOFT)(buffer, offset, samples, channels, type, data);
+ }
+ 
+ HL_PRIM void HL_NAME(al_get_buffer_samples_soft)(unsigned buffer, int offset, int samples, int channels, int type, vbyte *data) {
+ 	CHECK_EXT(alGetBufferSamplesSOFT);
+-	alGetBufferSamplesSOFT(buffer, offset, samples, channels, type, data);
++	CALL(alGetBufferSamplesSOFT)(buffer, offset, samples, channels, type, data);
+ }
+ 
+ HL_PRIM bool HL_NAME(al_is_buffer_format_supported_soft)(int format) {
+ 	CHECK_EXT(alIsBufferFormatSupportedSOFT);
+-	return alIsBufferFormatSupportedSOFT(format) == AL_TRUE;
++	return CALL(alIsBufferFormatSupportedSOFT)(format) == AL_TRUE;
+ }
+ 
+ DEFINE_PRIM(_VOID, al_buffer_samples_soft,              _I32 _I32 _I32 _I32 _I32 _I32 _BYTES);
+@@ -734,34 +736,34 @@ DEFINE_PRIM(_BOOL, al_is_buffer_format_supported_soft,  _I32);
+ 
+ HL_PRIM void HL_NAME(al_sourced_soft)(unsigned source, int param, double value) {
+ 	CHECK_EXT(alSourcedSOFT);
+-	alSourcedSOFT(source, param, value);
++	CALL(alSourcedSOFT)(source, param, value);
+ }
+ 
+ HL_PRIM void HL_NAME(al_source3d_soft)(unsigned source, int param, double value1, double value2, double value3) {
+ 	CHECK_EXT(alSource3dSOFT);
+-	alSource3dSOFT(source, param, value1, value2, value3);
++	CALL(alSource3dSOFT)(source, param, value1, value2, value3);
+ }
+ 
+ HL_PRIM void HL_NAME(al_sourcedv_soft)(unsigned source, int param, vbyte *values) {
+ 	CHECK_EXT(alSourcedvSOFT);
+-	alSourcedvSOFT(source, param, (ALdouble*)values);
++	CALL(alSourcedvSOFT)(source, param, (ALdouble*)values);
+ }
+ 
+ HL_PRIM double HL_NAME(al_get_sourced_soft)(unsigned source, int param) {
+ 	double value;
+ 	CHECK_EXT(alGetSourcedSOFT);
+-	alGetSourcedSOFT(source, param, &value);
++	CALL(alGetSourcedSOFT)(source, param, &value);
+ 	return value;
+ }
+ 
+ HL_PRIM void HL_NAME(al_get_source3d_soft)(unsigned source, int param, double *value1, double *value2, double *value3) {
+ 	CHECK_EXT(alGetSource3dSOFT);
+-	alGetSource3dSOFT(source, param, value1, value2, value3);
++	CALL(alGetSource3dSOFT)(source, param, value1, value2, value3);
+ }
+ 
+ HL_PRIM void HL_NAME(al_get_sourcedv_soft)(unsigned source, int param, vbyte *values) {
+ 	CHECK_EXT(alGetSourcedvSOFT);
+-	alGetSourcedvSOFT(source, param, (ALdouble*)values);
++	CALL(alGetSourcedvSOFT)(source, param, (ALdouble*)values);
+ }
+ 
+ #define I64_COMBINE(hi, lo) (((ALint64SOFT)hi) << 32) | lo
+@@ -770,13 +772,13 @@ HL_PRIM void HL_NAME(al_get_sourcedv_soft)(unsigned source, int param, vbyte *va
+ 
+ HL_PRIM void HL_NAME(al_sourcei64_soft)(unsigned source, int param, int valueHi, int valueLo) {
+ 	CHECK_EXT(alSourcei64SOFT);
+-	alSourcei64SOFT(source, param, I64_COMBINE(valueHi, valueLo));
++	CALL(alSourcei64SOFT)(source, param, I64_COMBINE(valueHi, valueLo));
+ }
+ 
+ HL_PRIM void HL_NAME(al_source3i64_soft)(unsigned source, int param, 
+ 		int value1Hi, int value1Lo, int value2Hi, int value2Lo, int value3Hi, int value3Lo) {
+ 	CHECK_EXT(alSource3i64SOFT);
+-	alSource3i64SOFT(source, param, 
++	CALL(alSource3i64SOFT)(source, param,
+ 		I64_COMBINE(value1Hi, value1Lo), 
+ 		I64_COMBINE(value2Hi, value2Lo), 
+ 		I64_COMBINE(value3Hi, value3Lo));
+@@ -784,13 +786,13 @@ HL_PRIM void HL_NAME(al_source3i64_soft)(unsigned source, int param,
+ 
+ HL_PRIM void HL_NAME(al_sourcei64v_soft)(unsigned source, int param, vbyte *values) {
+ 	CHECK_EXT(alSourcei64vSOFT);
+-	alSourcei64vSOFT(source, param, (ALint64SOFT*)values);
++	CALL(alSourcei64vSOFT)(source, param, (ALint64SOFT*)values);
+ }
+ 
+ HL_PRIM void HL_NAME(al_get_sourcei64_soft)(unsigned source, int param, int *valueHi, int *valueLo) {
+ 	ALint64SOFT value;
+ 	CHECK_EXT(alGetSourcei64SOFT);
+-	alGetSourcei64SOFT(source, param, &value);
++	CALL(alGetSourcei64SOFT)(source, param, &value);
+ 	*valueHi = I64_HI(value);
+ 	*valueLo = I64_LO(value);
+ }
+@@ -799,7 +801,7 @@ HL_PRIM void HL_NAME(al_get_source3i64_soft)(unsigned source, int param,
+ 		int *value1Hi, int *value1Lo, int *value2Hi, int *value2Lo, int *value3Hi, int *value3Lo) {
+ 	ALint64SOFT value1, value2, value3;
+ 	CHECK_EXT(alGetSource3i64SOFT);
+-	alGetSource3i64SOFT(source, param, &value1, &value2, &value3);
++	CALL(alGetSource3i64SOFT)(source, param, &value1, &value2, &value3);
+ 	*value1Hi = I64_HI(value1);
+ 	*value1Lo = I64_LO(value1);
+ 	*value2Hi = I64_HI(value2);
+@@ -810,7 +812,7 @@ HL_PRIM void HL_NAME(al_get_source3i64_soft)(unsigned source, int param,
+ 
+ HL_PRIM void HL_NAME(al_get_sourcei64v_soft)(unsigned source, int param, vbyte *values) {
+ 	CHECK_EXT(alGetSourcei64vSOFT);
+-	alGetSourcei64vSOFT(source, param, (ALint64SOFT*)values);
++	CALL(alGetSourcei64vSOFT)(source, param, (ALint64SOFT*)values);
+ }
+ 
+ DEFINE_PRIM(_VOID, al_sourced_soft,  _I32 _I32 _F64);
+@@ -836,12 +838,12 @@ DEFINE_PRIM(_VOID, al_get_sourcei64v_soft, _I32 _I32 _BYTES);
+ 
+ HL_PRIM void HL_NAME(al_defer_updates_soft)() {
+ 	CHECK_EXT(alDeferUpdatesSOFT);
+-	alDeferUpdatesSOFT();
++	CALL(alDeferUpdatesSOFT)();
+ }
+ 
+ HL_PRIM void HL_NAME(al_process_updates_soft)() {
+ 	CHECK_EXT(alProcessUpdatesSOFT);
+-	alProcessUpdatesSOFT();
++	CALL(alProcessUpdatesSOFT)();
+ }
+ 
+ DEFINE_PRIM(_VOID, al_defer_updates_soft,   _NO_ARG);
+@@ -853,51 +855,51 @@ DEFINE_PRIM(_VOID, al_process_updates_soft, _NO_ARG);
+ // ----------------------------------------------------------------------------
+ 
+ HL_PRIM void HL_NAME(al_gen_effects)(int n, vbyte *effects) {
+-	alGenEffects(n, (ALuint*)effects);
++	CALL(alGenEffects)(n, (ALuint*)effects);
+ }
+ 
+ HL_PRIM void HL_NAME(al_delete_effects)(int n, vbyte *effects) {
+-	alDeleteEffects(n, (ALuint*)effects);
++	CALL(alDeleteEffects)(n, (ALuint*)effects);
+ }
+ 
+ HL_PRIM bool HL_NAME(al_is_effect)(unsigned effect) {
+-	return alIsEffect(effect) == AL_TRUE;
++	return CALL(alIsEffect)(effect) == AL_TRUE;
+ }
+ 
+ HL_PRIM void HL_NAME(al_effecti)(unsigned effect, int param, int iValue) {
+-	alEffecti(effect, param, iValue);
++	CALL(alEffecti)(effect, param, iValue);
+ }
+ 
+ HL_PRIM void HL_NAME(al_effectiv)(unsigned effect, int param, vbyte *piValues) {
+-	alEffectiv(effect, param, (ALint*)piValues);
++	CALL(alEffectiv)(effect, param, (ALint*)piValues);
+ }
+ 
+ HL_PRIM void HL_NAME(al_effectf)(unsigned effect, int param, float flValue) {
+-	alEffectf(effect, param, flValue);
++	CALL(alEffectf)(effect, param, flValue);
+ }
+ 
+ HL_PRIM void HL_NAME(al_effectfv)(unsigned effect, int param, vbyte *pflValues) {
+-	alEffectfv(effect, param, (ALfloat*)pflValues);
++	CALL(alEffectfv)(effect, param, (ALfloat*)pflValues);
+ }
+ 
+ HL_PRIM int HL_NAME(al_get_effecti)(unsigned effect, int param) {
+ 	int value;
+-	alGetEffecti(effect, param, &value);
++	CALL(alGetEffecti)(effect, param, &value);
+ 	return value;
+ }
+ 
+ HL_PRIM void HL_NAME(al_get_effectiv)(unsigned effect, int param, vbyte *piValues) {
+-	alGetEffectiv(effect, param, (ALint*)piValues);
++	CALL(alGetEffectiv)(effect, param, (ALint*)piValues);
+ }
+ 
+ HL_PRIM float HL_NAME(al_get_effectf)(unsigned effect, int param) {
+ 	float value;
+-	alGetEffectf(effect, param, &value);
++	CALL(alGetEffectf)(effect, param, &value);
+ 	return value;
+ }
+ 
+ HL_PRIM void HL_NAME(al_get_effectfv)(unsigned effect, int param, vbyte *pflValues) {
+-	alGetEffectfv(effect, param, (ALfloat*)pflValues);
++	CALL(alGetEffectfv)(effect, param, (ALfloat*)pflValues);
+ }
+ 
+ DEFINE_PRIM(_VOID, al_gen_effects,    _I32 _BYTES);
+@@ -917,51 +919,51 @@ DEFINE_PRIM(_VOID, al_get_effectfv,   _I32 _I32 _BYTES);
+ // ----------------------------------------------------------------------------
+ 
+ HL_PRIM void HL_NAME(al_gen_filters)(int n, vbyte *filters) {
+-	alGenFilters(n, (ALuint*)filters);
++	CALL(alGenFilters)(n, (ALuint*)filters);
+ }
+ 
+ HL_PRIM void HL_NAME(al_delete_filters)(int n, vbyte *filters) {
+-	alDeleteFilters(n, (ALuint*)filters);
++	CALL(alDeleteFilters)(n, (ALuint*)filters);
+ }
+ 
+ HL_PRIM bool HL_NAME(al_is_filter)(unsigned filter) {
+-	return alIsFilter(filter) == AL_TRUE;
++	return CALL(alIsFilter)(filter) == AL_TRUE;
+ }
+ 
+ HL_PRIM void HL_NAME(al_filteri)(unsigned filter, int param, int iValue) {
+-	alFilteri(filter, param, iValue);
++	CALL(alFilteri)(filter, param, iValue);
+ }
+ 
+ HL_PRIM void HL_NAME(al_filteriv)(unsigned filter, int param, vbyte *piValues) {
+-	alFilteriv(filter, param, (ALint*)piValues);
++	CALL(alFilteriv)(filter, param, (ALint*)piValues);
+ }
+ 
+ HL_PRIM void HL_NAME(al_filterf)(unsigned filter, int param, float flValue) {
+-	alFilterf(filter, param, flValue);
++	CALL(alFilterf)(filter, param, flValue);
+ }
+ 
+ HL_PRIM void HL_NAME(al_filterfv)(unsigned filter, int param, vbyte *pflValues) {
+-	alFilterfv(filter, param, (ALfloat*)pflValues);
++	CALL(alFilterfv)(filter, param, (ALfloat*)pflValues);
+ }
+ 
+ HL_PRIM int HL_NAME(al_get_filteri)(unsigned filter, int param) {
+ 	int value;
+-	alGetFilteri(filter, param, &value);
++	CALL(alGetFilteri)(filter, param, &value);
+ 	return value;
+ }
+ 
+ HL_PRIM void HL_NAME(al_get_filteriv)(unsigned filter, int param, vbyte *piValues) {
+-	alGetFilteriv(filter, param, (ALint*)piValues);
++	CALL(alGetFilteriv)(filter, param, (ALint*)piValues);
+ }
+ 
+ HL_PRIM float HL_NAME(al_get_filterf)(unsigned filter, int param) {
+ 	float value;
+-	alGetFilterf(filter, param, &value);
++	CALL(alGetFilterf)(filter, param, &value);
+ 	return value;
+ }
+ 
+ HL_PRIM void HL_NAME(al_get_filterfv)(unsigned filter, int param, vbyte *pflValues) {
+-	alGetFilterfv(filter, param, (ALfloat*)pflValues);
++	CALL(alGetFilterfv)(filter, param, (ALfloat*)pflValues);
+ }
+ 
+ DEFINE_PRIM(_VOID, al_gen_filters,    _I32 _BYTES);
+@@ -981,51 +983,51 @@ DEFINE_PRIM(_VOID, al_get_filterfv,   _I32 _I32 _BYTES);
+ // ----------------------------------------------------------------------------
+ 
+ HL_PRIM void HL_NAME(al_gen_auxiliary_effect_slots)(int n, vbyte *effectslots) {
+-	alGenAuxiliaryEffectSlots(n, (ALuint*)effectslots);
++	CALL(alGenAuxiliaryEffectSlots)(n, (ALuint*)effectslots);
+ }
+ 
+ HL_PRIM void HL_NAME(al_delete_auxiliary_effect_slots)(int n, vbyte *effectslots) {
+-	alDeleteAuxiliaryEffectSlots(n, (ALuint*)effectslots);
++	CALL(alDeleteAuxiliaryEffectSlots)(n, (ALuint*)effectslots);
+ }
+ 
+ HL_PRIM bool HL_NAME(al_is_auxiliary_effect_slot)(unsigned effectslot) {
+-	return alIsAuxiliaryEffectSlot(effectslot) == AL_TRUE;
++	return CALL(alIsAuxiliaryEffectSlot)(effectslot) == AL_TRUE;
+ }
+ 
+ HL_PRIM void HL_NAME(al_auxiliary_effect_sloti)(unsigned effectslot, int param, int iValue) {
+-	alAuxiliaryEffectSloti(effectslot, param, iValue);
++	CALL(alAuxiliaryEffectSloti)(effectslot, param, iValue);
+ }
+ 
+ HL_PRIM void HL_NAME(al_auxiliary_effect_slotiv)(unsigned effectslot, int param, vbyte *piValues) {
+-	alAuxiliaryEffectSlotiv(effectslot, param, (ALint*)piValues);
++	CALL(alAuxiliaryEffectSlotiv)(effectslot, param, (ALint*)piValues);
+ }
+ 
+ HL_PRIM void HL_NAME(al_auxiliary_effect_slotf)(unsigned effectslot, int param, float flValue) {
+-	alAuxiliaryEffectSlotf(effectslot, param, flValue);
++	CALL(alAuxiliaryEffectSlotf)(effectslot, param, flValue);
+ }
+ 
+ HL_PRIM void HL_NAME(al_auxiliary_effect_slotfv)(unsigned effectslot, int param, vbyte *pflValues) {
+-	alAuxiliaryEffectSlotfv(effectslot, param, (ALfloat*)pflValues);
++	CALL(alAuxiliaryEffectSlotfv)(effectslot, param, (ALfloat*)pflValues);
+ }
+ 
+ HL_PRIM int HL_NAME(al_get_auxiliary_effect_sloti)(unsigned effectslot, int param) {
+ 	int value;
+-	alGetAuxiliaryEffectSloti(effectslot, param, &value);
++	CALL(alGetAuxiliaryEffectSloti)(effectslot, param, &value);
+ 	return value;
+ }
+ 
+ HL_PRIM void HL_NAME(al_get_auxiliary_effect_slotiv)(unsigned effectslot, int param, vbyte *piValues) {
+-	alGetAuxiliaryEffectSlotiv(effectslot, param, (ALint*)piValues);
++	CALL(alGetAuxiliaryEffectSlotiv)(effectslot, param, (ALint*)piValues);
+ }
+ 
+ HL_PRIM float HL_NAME(al_get_auxiliary_effect_slotf)(unsigned effectslot, int param) {
+ 	float value;
+-	alGetAuxiliaryEffectSlotf(effectslot, param, &value);
++	CALL(alGetAuxiliaryEffectSlotf)(effectslot, param, &value);
+ 	return value;
+ }
+ 
+ HL_PRIM void HL_NAME(al_get_auxiliary_effect_slotfv)(unsigned effectslot, int param, vbyte *pflValues) {
+-	alGetAuxiliaryEffectSlotfv(effectslot, param, (ALfloat*)pflValues);
++	CALL(alGetAuxiliaryEffectSlotfv)(effectslot, param, (ALfloat*)pflValues);
+ }
+ 
+ DEFINE_PRIM(_VOID, al_gen_auxiliary_effect_slots,    _I32 _BYTES);
+@@ -1041,4 +1043,4 @@ DEFINE_PRIM(_I32,  al_get_auxiliary_effect_sloti,    _I32 _I32);
+ DEFINE_PRIM(_VOID, al_get_auxiliary_effect_slotiv,   _I32 _I32 _BYTES);
+ DEFINE_PRIM(_F32,  al_get_auxiliary_effect_slotf,    _I32 _I32);
+ DEFINE_PRIM(_VOID, al_get_auxiliary_effect_slotfv,   _I32 _I32 _BYTES);
+-#endif
+\ No newline at end of file
++#endif

--- a/xmake.lua
+++ b/xmake.lua
@@ -197,7 +197,7 @@ function compile_flags(target)
     end
 end
 
--- This function is used to combine multiple actions on same xmake hook.
+-- It's a utility function to combine multiple actions on same xmake hook.
 function chain_actions(...)
     local args = { ... }
     return function(target)


### PR DESCRIPTION
Openal.hdll was not able to build statically because of the existing of libsndio. By default libsndio requires building as a shared library, thus, it breaks the dependency chain (hashlink::openal.hdll -> openal-soft -> libsndio -> alsa-lib) when trying to build with -static-libgcc and -static-libstdc++.

There are two possible fixes: a) convert libsndio as a static library, and b) add -static-libgcc and -static-libstdc++ to libsndio.so. The final solution I chose is a). It requires three steps:

1. Provide a private package for libsndio to allow it build a static libsndio-static.a.
    Note that this is not accepted by official.
2. Change my own xmake.lua. Use set_requireconfs() to require the full chain building in static library.
3. Apply openal.hdll patch to avoid static library link error. Note this is not accepted by official Hashlink.

With the changes, we ends up with a libopenal.a, which depends on only libhl.so, libm.so.6, libc.so.6, and ld-linux-x86-64.so.2. The risky libraries, libgcc_s.so.6 and libstdc++.so.6, are embeded to openal.hdll.

The reason we don't use solution b) is, when libsndio is a shared library, then openal-soft needs to be a shared library as well. openal-soft is a C++ library, which explicitly requires libstdc++.so.6. This is too risky for portability.